### PR TITLE
Show keyboard for URL and username fields in registration screen

### DIFF
--- a/app/src/main/java/org/igarape/copcast/utils/EditTextUtils.java
+++ b/app/src/main/java/org/igarape/copcast/utils/EditTextUtils.java
@@ -1,0 +1,42 @@
+package org.igarape.copcast.utils;
+
+import android.content.Context;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
+
+/**
+ * Created by dborkan on 5/18/16.
+ */
+public class EditTextUtils {
+    public static void showKeyboardOnFocusAndClick(final android.app.Activity activity, final TextView tv) {
+        // Show the keyboard when the user first focuses in the field.
+        tv.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    showKeyboard(activity, tv);
+                }
+            }
+        });
+        // Show keyboard on click, in case the user has closed the keyboard.
+        // Click does not fire when the user first focuses in the field.
+        tv.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showKeyboard(activity, tv);
+            }
+        });
+    }
+
+    public static void showKeyboard(final android.app.Activity activity, final TextView tv) {
+        tv.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                InputMethodManager keyboard = (InputMethodManager)
+                        activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+                keyboard.showSoftInput(tv, 0);
+            }
+        }, 200);
+    }
+}

--- a/app/src/main/java/org/igarape/copcast/views/LoginActivity.java
+++ b/app/src/main/java/org/igarape/copcast/views/LoginActivity.java
@@ -26,6 +26,7 @@ import org.igarape.copcast.R;
 import org.igarape.copcast.promises.HttpPromiseError;
 import org.igarape.copcast.promises.PromiseError;
 import org.igarape.copcast.state.State;
+import org.igarape.copcast.utils.EditTextUtils;
 import org.igarape.copcast.utils.Globals;
 import org.igarape.copcast.promises.Promise;
 import org.igarape.copcast.promises.PromisePayload;
@@ -57,27 +58,9 @@ public class LoginActivity extends Activity {
         txtId = (EditText) findViewById(R.id.txtLoginUser);
         txtPwd = (EditText) findViewById(R.id.txtLoginPassword);
         Button btnLoginOk = (Button) findViewById(R.id.btn_login_ok);
-        /**
-         * Appears a hack
-         * On login_activity I added
-         * android:focusable="true"
-         * android:focusableInTouchMode="true"
-         */
-        txtId.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if (hasFocus) {
-                    txtId.postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            InputMethodManager keyboard = (InputMethodManager)
-                                    getSystemService(Context.INPUT_METHOD_SERVICE);
-                            keyboard.showSoftInput(txtId, 0);
-                        }
-                    }, 200);
-                }
-            }
-        });
+
+        EditTextUtils.showKeyboard(this, txtId);
+        EditTextUtils.showKeyboardOnFocusAndClick(this, txtId);
 
         btnLoginOk.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
+++ b/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
@@ -10,7 +10,6 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;

--- a/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
+++ b/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -57,6 +58,10 @@ public class RegistrationActivity extends Activity {
                 doRegister();
             }
         });
+
+        showKeyboard(register_url);
+        showKeyboardOnFocusAndClick(register_url);
+        showKeyboardOnFocusAndClick(register_username);
     }
 
     private void doRegister() {
@@ -103,5 +108,36 @@ public class RegistrationActivity extends Activity {
                 return null;
             }
         }.execute();
+    }
+
+    private void showKeyboard(final TextView tv) {
+        tv.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                InputMethodManager keyboard = (InputMethodManager)
+                        getSystemService(Context.INPUT_METHOD_SERVICE);
+                keyboard.showSoftInput(tv, 0);
+            }
+        }, 200);
+    }
+
+    private void showKeyboardOnFocusAndClick(final TextView tv) {
+        // Show the keyboard when the user first focuses in the field.
+        tv.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
+                if (hasFocus) {
+                    showKeyboard(tv);
+                }
+            }
+        });
+        // Show keyboard on click, in case the user has closed the keyboard.
+        // Click does not fire when the user first focuses in the field.
+        tv.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showKeyboard(tv);
+            }
+        });
     }
 }

--- a/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
+++ b/app/src/main/java/org/igarape/copcast/views/RegistrationActivity.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import org.igarape.copcast.R;
 import org.igarape.copcast.service.sign.SigningService;
 import org.igarape.copcast.service.sign.SigningServiceException;
+import org.igarape.copcast.utils.EditTextUtils;
 import org.igarape.copcast.utils.Globals;
 import org.igarape.copcast.utils.OkDialog;
 import org.igarape.copcast.promises.Promise;
@@ -59,9 +60,9 @@ public class RegistrationActivity extends Activity {
             }
         });
 
-        showKeyboard(register_url);
-        showKeyboardOnFocusAndClick(register_url);
-        showKeyboardOnFocusAndClick(register_username);
+        EditTextUtils.showKeyboard(this, register_url);
+        EditTextUtils.showKeyboardOnFocusAndClick(this, register_url);
+        EditTextUtils.showKeyboardOnFocusAndClick(this, register_username);
     }
 
     private void doRegister() {
@@ -108,36 +109,5 @@ public class RegistrationActivity extends Activity {
                 return null;
             }
         }.execute();
-    }
-
-    private void showKeyboard(final TextView tv) {
-        tv.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                InputMethodManager keyboard = (InputMethodManager)
-                        getSystemService(Context.INPUT_METHOD_SERVICE);
-                keyboard.showSoftInput(tv, 0);
-            }
-        }, 200);
-    }
-
-    private void showKeyboardOnFocusAndClick(final TextView tv) {
-        // Show the keyboard when the user first focuses in the field.
-        tv.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override
-            public void onFocusChange(View v, boolean hasFocus) {
-                if (hasFocus) {
-                    showKeyboard(tv);
-                }
-            }
-        });
-        // Show keyboard on click, in case the user has closed the keyboard.
-        // Click does not fire when the user first focuses in the field.
-        tv.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showKeyboard(tv);
-            }
-        });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/igarape/copcast-android/issues/117

We now show the keyboard anytime the username or registration fields are focused or clicked (in case the keyboard was hidden).  I've created an EditTextUtils function so the same code can be re-used in both LoginActivity and RegistrationActivity.