### PR TITLE
Block login + start mission of high accuracy location disabled, show warning during mission

### DIFF
--- a/app/src/main/java/org/igarape/copcast/utils/LocationUtils.java
+++ b/app/src/main/java/org/igarape/copcast/utils/LocationUtils.java
@@ -1,9 +1,15 @@
 package org.igarape.copcast.utils;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
 import android.location.Location;
+import android.location.LocationManager;
+import android.provider.Settings;
 import android.util.Log;
 
+import org.igarape.copcast.R;
 import org.igarape.copcast.promises.Promise;
 import org.igarape.copcast.promises.PromiseError;
 import org.json.JSONException;
@@ -39,6 +45,8 @@ public class LocationUtils {
     public static final long FAST_INTERVAL_CEILING_IN_MILLISECONDS =
             MILLISECONDS_PER_SECOND * FAST_CEILING_IN_SECONDS;
     public static final float SMALLEST_DISPLACEMENT = 0;
+
+    private static AlertDialog mHighAccuracyLocationDisabledAlertDialog;
 
     public static void sendLocation(Context context, final String login, final Location location) {
         Promise callback = new Promise() {
@@ -94,5 +102,36 @@ public class LocationUtils {
             json.put("speed", speed);
         }
         return json;
+    }
+
+    public static boolean isHighAccuracyLocationEnabled(android.app.Activity activity) {
+        final LocationManager location_manager =
+                (LocationManager) activity.getSystemService(Context.LOCATION_SERVICE);
+        return location_manager.isProviderEnabled(LocationManager.GPS_PROVIDER) &&
+                location_manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    }
+
+    public static void showHighAccuracyLocationDisabledAlert(final android.app.Activity activity) {
+        if (mHighAccuracyLocationDisabledAlertDialog != null &&
+                mHighAccuracyLocationDisabledAlertDialog.isShowing()) {
+            // Dialog is already showing, don't show again.
+            return;
+        }
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                builder.setMessage(R.string.high_accuracy_location_dialog_msg)
+                        .setCancelable(true)
+                        .setPositiveButton(R.string.enable, new DialogInterface.OnClickListener() {
+                            public void onClick(final DialogInterface dialog, final int id) {
+                                activity.startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+                            }
+                        });
+                mHighAccuracyLocationDisabledAlertDialog = builder.create();
+                mHighAccuracyLocationDisabledAlertDialog.show();
+            }
+        });
     }
 }

--- a/app/src/main/java/org/igarape/copcast/views/LoginActivity.java
+++ b/app/src/main/java/org/igarape/copcast/views/LoginActivity.java
@@ -1,9 +1,12 @@
 package org.igarape.copcast.views;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.location.LocationManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -30,6 +33,7 @@ import org.igarape.copcast.utils.EditTextUtils;
 import org.igarape.copcast.utils.Globals;
 import org.igarape.copcast.promises.Promise;
 import org.igarape.copcast.promises.PromisePayload;
+import org.igarape.copcast.utils.LocationUtils;
 import org.igarape.copcast.utils.NetworkUtils;
 import org.igarape.copcast.utils.OkDialog;
 import org.igarape.copcast.utils.StateManager;
@@ -104,6 +108,10 @@ public class LoginActivity extends Activity {
     }
 
     public void makeLoginRequest(View view) {
+        if (!LocationUtils.isHighAccuracyLocationEnabled(this)) {
+            LocationUtils.showHighAccuracyLocationDisabledAlert(this);
+            return;
+        }
 
         pDialog = new ProgressDialog(this);
         pDialog.setTitle(getString(R.string.login_in));
@@ -203,25 +211,5 @@ public class LoginActivity extends Activity {
             }
 
         }.execute(null, null, null);
-    }
-
-    private boolean hasErrors() {
-        final String login = txtId.getText().toString();
-        final String password = txtPwd.getText().toString();
-        if (login.isEmpty()) {
-            Log.d(TAG, "login required");
-            Toast toast = Toast.makeText(getApplicationContext(), R.string.login_required, Toast.LENGTH_LONG);
-            toast.setGravity(Gravity.TOP, 0, 100);
-            toast.show();
-            return true;
-        }
-        if (password.isEmpty()) {
-            Log.d(TAG, "password required");
-            Toast toast = Toast.makeText(getApplicationContext(), R.string.password_required, Toast.LENGTH_LONG);
-            toast.setGravity(Gravity.TOP, 0, 100);
-            toast.show();
-            return true;
-        }
-        return false;
     }
 }

--- a/app/src/main/res/layout/activity_registration.xml
+++ b/app/src/main/res/layout/activity_registration.xml
@@ -34,11 +34,11 @@
         android:hint="@string/server_url_hint"
         android:layout_below="@+id/horizontalRule"
         android:layout_marginTop="16dp"
-        android:inputType="text"
         android:textColor="#FFFFFF"
         android:textColorHighlight="#FFFFFF"
         android:textColorLink="#FFFFFF"
-        android:textIsSelectable="true" />
+        android:textIsSelectable="true"
+        android:inputType="text" />
 
     <EditText
         android:layout_width="match_parent"

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -119,4 +119,6 @@
     <string name="automatic_upload">Upload automático</string>
     <string name="automatic_upload_desc">Iniciar automaticamente o upload quando conectado ao carregador.</string>
     <string name="start_automatic_upload">Iniciando upload automático</string>
+    <string name="high_accuracy_location_dialog_msg">Você deve habilitar a localização de alta precisão para utilizar o Copcast</string>
+    <string name="enable">Habilitar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,6 @@
     <string name="automatic_upload">Automatic upload</string>
     <string name="automatic_upload_desc">Automatically start uploading while connected to the power supply.</string>
     <string name="start_automatic_upload">Starting automatic upload</string>
+    <string name="high_accuracy_location_dialog_msg">You must enable high accuracy location services to use Copcast</string>
+    <string name="enable">Enable</string>
 </resources>


### PR DESCRIPTION
Fixes https://github.com/igarape/copcast-android/issues/150

* Block the user from logging in or starting a mission if high accuracy location is disabled
* If the user is currently in a mission and high accuracy location has been disabled for some reason, show the same alert and vibrate their phone every 5 seconds.